### PR TITLE
Enable pipx install and fix ELF linter warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,6 @@ types-paramiko = "^3.5.0.20250516"
 types-pyyaml = "^6.0.12.20250516"
 ruff = "^0.11.13"
 types-jsonschema = "^4.24.0.20250528"
+
+[project.scripts]
+envicorn = "test_env_setup_util.env_setup:main"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,6 +40,8 @@ parts:
     # https://documentation.ubuntu.com/snapcraft/stable/reference/plugins/python_plugin/
     # https://documentation.ubuntu.com/snapcraft/stable/reference/plugins/poetry_plugin/
     plugin: poetry
+    build-attributes:
+      - enable-patchelf
     source: .
     build-packages:
       - pipx # poetry is distributed with pipx

--- a/test_env_setup_util/env_setup.py
+++ b/test_env_setup_util/env_setup.py
@@ -9,7 +9,11 @@ import sys
 import paramiko.ssh_exception
 import yaml
 
-from test_env_setup_util.libs.common import validate_file_content, _check_file, _load_file
+from test_env_setup_util.libs.common import (
+    validate_file_content,
+    _check_file,
+    _load_file,
+)
 from test_env_setup_util.libs.exceptions import ExitCode
 from test_env_setup_util.libs.operator.common import (
     ssh_command,

--- a/test_env_setup_util/env_setup.py
+++ b/test_env_setup_util/env_setup.py
@@ -9,16 +9,16 @@ import sys
 import paramiko.ssh_exception
 import yaml
 
-from libs.common import validate_file_content, _check_file, _load_file
-from libs.exceptions import ExitCode
-from libs.operator.common import (
+from test_env_setup_util.libs.common import validate_file_content, _check_file, _load_file
+from test_env_setup_util.libs.exceptions import ExitCode
+from test_env_setup_util.libs.operator.common import (
     ssh_command,
     scp_command,
     create_system_service,
 )
-from libs.operator.debian import install_debian
-from libs.operator.snap import install_snap
-from libs.ssh_handler import RemoteSshSession
+from test_env_setup_util.libs.operator.debian import install_debian
+from test_env_setup_util.libs.operator.snap import install_snap
+from test_env_setup_util.libs.ssh_handler import RemoteSshSession
 from pathlib import Path
 
 

--- a/test_env_setup_util/libs/operator/common.py
+++ b/test_env_setup_util/libs/operator/common.py
@@ -1,11 +1,7 @@
 import logging
 import os
 import tempfile
-
 from pathlib import Path
-import paramiko.ssh_exception
-
-from test_env_setup_util.libs.common import _check_file
 
 
 def ssh_command(session, data):

--- a/test_env_setup_util/libs/operator/common.py
+++ b/test_env_setup_util/libs/operator/common.py
@@ -3,6 +3,9 @@ import os
 import tempfile
 
 from pathlib import Path
+import paramiko.ssh_exception
+
+from test_env_setup_util.libs.common import _check_file
 
 
 def ssh_command(session, data):

--- a/test_env_setup_util/libs/operator/snap.py
+++ b/test_env_setup_util/libs/operator/snap.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from libs.exceptions import SnapCommandError
+from test_env_setup_util.libs.exceptions import SnapCommandError
 
 
 def install_snap(session, snap_data):

--- a/test_env_setup_util/libs/ssh_handler.py
+++ b/test_env_setup_util/libs/ssh_handler.py
@@ -2,7 +2,7 @@ import logging
 import paramiko
 
 from contextlib import contextmanager
-from libs.exceptions import SshCommandError
+from test_env_setup_util.libs.exceptions import SshCommandError
 from pathlib import Path
 from scp import SCPClient, SCPException
 


### PR DESCRIPTION
## Enable pipx install

This PR makes it even easier to install envicorn. It's something I've been using on my own [cli tools branch](https://github.com/canonical/ceqa-jira-ops-automator/tree/oem-qa-cli-tools). With these changes we only need to do:

```sh
sudo apt update && sudo apt install pipx
export PATH=$HOME/.local/bin:$PATH
pipx install git+https://github.com/canonical/envicorn.git
```

to get the `envicorn` command. pipx will setup all the packages and environment for us as well as adding the command to $PATH.
- The export step is only necessary for fresh environments. If `$HOME/.local/bin` can be permanently added into the environment then we won't need it.
- Before it gets merged into main, we can install from this branch: `pipx install git+https://github.com/canonical/envicorn.git@enable-pipx-install` 

To change the command name, change the name in pyproject.toml's `[project.scripts]` section. More commands can also be added there and pipx will install them automatically.

To uninstall, `pipx uninstall envicorn`

To list commands installed through pipx, `pipx list`. This also shows the install $PATH which is helpful for "command not found" issues.

## ELF linter warning

When building the snap there was a massive wall of warnings. The `build-attributes: enable-patchelf` line fixes them.
- Original answer here: https://forum.snapcraft.io/t/how-to-set-up-classic-confinement/34416