### PR TITLE
Add the DEBIAN_FRONTEND=noninteractive for install the deb pkg

### DIFF
--- a/test_env_setup_util/libs/operator/debian.py
+++ b/test_env_setup_util/libs/operator/debian.py
@@ -4,7 +4,7 @@ import logging
 def install_debian(session, debian_data):
     session.launch_ssh_command("sudo apt update")
     # Install debian package
-    _cmd = f"sudo apt install {debian_data['name']} -y"
+    _cmd = f"sudo apt install DEBIAN_FRONTEND=noninteractive -y {debian_data['name']}"
     if debian_data.get("revision"):
         _cmd += f"={debian_data['rivision']}"
 


### PR DESCRIPTION
Add the DEBIAN_FRONTEND=noninteractive for install the deb pkg

some debian pkg will ask user the check if they want to restart the service or something else, and this will block the envicorn actions.