### PR TITLE
Correct the DEBIAN_FRONTED parameter

### DIFF
--- a/test_env_setup_util/libs/operator/debian.py
+++ b/test_env_setup_util/libs/operator/debian.py
@@ -4,7 +4,7 @@ import logging
 def install_debian(session, debian_data):
     session.launch_ssh_command("sudo apt update")
     # Install debian package
-    _cmd = f"sudo apt install DEBIAN_FRONTEND=noninteractive -y {debian_data['name']}"
+    _cmd = f"sudo DEBIAN_FRONTEND=noninteractive apt install -y {debian_data['name']}"
     if debian_data.get("revision"):
         _cmd += f"={debian_data['rivision']}"
 


### PR DESCRIPTION
Correct the cmd error

original (wrong):

```sh
$ sudo apt install DEBIAN_FRONTEND=noninteractive -y alsa-utils
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package DEBIAN_FRONTEND

```

Fixed (correct):

```sh
$ sudo DEBIAN_FRONTEND=noninteractive apt install -y alsa-utils --dry-run
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following additional packages will be installed:
  libatopology2 libfftw3-single3 libgomp1 libsamplerate0
Suggested packages:
  dialog libfftw3-bin libfftw3-dev
The following NEW packages will be installed:
  alsa-utils libatopology2 libfftw3-single3 libgomp1 libsamplerate0
0 upgraded, 5 newly installed, 0 to remove and 29 not upgraded.
Inst libatopology2 (1.2.6.1-1ubuntu1 Ubuntu:22.04/jammy [arm64])
Inst libgomp1 (12.3.0-1ubuntu1~22.04 Ubuntu:22.04/jammy-updates, Ubuntu:22.04/jammy-security [arm64])
Inst libfftw3-single3 (3.3.8-2ubuntu8 Ubuntu:22.04/jammy [arm64])
Inst libsamplerate0 (0.2.2-1build1 Ubuntu:22.04/jammy [arm64])
Inst alsa-utils (1.2.6-1ubuntu1 Ubuntu:22.04/jammy [arm64])
Conf libatopology2 (1.2.6.1-1ubuntu1 Ubuntu:22.04/jammy [arm64])
Conf libgomp1 (12.3.0-1ubuntu1~22.04 Ubuntu:22.04/jammy-updates, Ubuntu:22.04/jammy-security [arm64])
Conf libfftw3-single3 (3.3.8-2ubuntu8 Ubuntu:22.04/jammy [arm64])
Conf libsamplerate0 (0.2.2-1build1 Ubuntu:22.04/jammy [arm64])
Conf alsa-utils (1.2.6-1ubuntu1 Ubuntu:22.04/jammy [arm64])

```