### PR TITLE
add retry mechanism for snap/deb install action

### DIFF
--- a/test_env_setup_util/libs/model.py
+++ b/test_env_setup_util/libs/model.py
@@ -24,6 +24,9 @@ class InstallSnapAction(BaseAction):
     revision: str | None = None
     mode: str = ""
     post_commands: str | None = None
+    retry_on_failure: bool = False
+    retry_count: int = 3
+    retry_delay: int = 5
 
     @field_validator("mode")
     def check_mode(cls, mode: str):
@@ -57,6 +60,9 @@ class InstallDebianAction(BaseAction):
     name: str
     repo: str | None = None
     revision: str | None = None
+    retry_on_failure: bool = False
+    retry_count: int = 3
+    retry_delay: int = 5
 
 
 class SshCommandAction(BaseAction):

--- a/test_env_setup_util/libs/operator/debian.py
+++ b/test_env_setup_util/libs/operator/debian.py
@@ -1,12 +1,59 @@
 import logging
+import time
+
+from test_env_setup_util.libs.exceptions import SshCommandError
 
 
 def install_debian(session, debian_data):
-    session.launch_ssh_command("sudo apt update")
-    # Install debian package
+    retry_on_failure = debian_data.get("retry_on_failure", False)
+    retry_count = (
+        debian_data.get("retry_count", 3) if retry_on_failure else None
+    )
+    retry_delay = (
+        debian_data.get("retry_delay", 5) if retry_on_failure else None
+    )
+
     _cmd = f"sudo DEBIAN_FRONTEND=noninteractive apt install -y {debian_data['name']}"
     if debian_data.get("revision"):
         _cmd += f"={debian_data['revision']}"
 
-    logging.info("install %s debian package", debian_data["name"])
-    session.launch_ssh_command(_cmd)
+    if retry_on_failure:
+        for attempt in range(retry_count):
+            update_exit_code, _, _ = session.launch_ssh_command(
+                "sudo apt update", continue_on_error=True
+            )
+            if update_exit_code == 0:
+                break
+            logging.warning(
+                "Attempt %d: 'sudo apt update' failed with exit code %d",
+                attempt + 1,
+                update_exit_code,
+            )
+            if attempt < retry_count - 1:
+                time.sleep(retry_delay)
+        else:
+            raise SshCommandError(
+                "Failed to update package list after retries"
+            )
+
+        for attempt in range(retry_count):
+            install_exit_code, _, _ = session.launch_ssh_command(
+                _cmd, continue_on_error=True
+            )
+            if install_exit_code == 0:
+                break
+            logging.warning(
+                "Attempt %d: '%s' failed with exit code %d",
+                attempt + 1,
+                _cmd,
+                install_exit_code,
+            )
+            if attempt < retry_count - 1:
+                time.sleep(retry_delay)
+        else:
+            raise SshCommandError(
+                f"Failed to install debian package '{debian_data['name']}' after {retry_count} retries"
+            )
+    else:
+        session.launch_ssh_command("sudo apt update")
+        session.launch_ssh_command(_cmd)

--- a/test_env_setup_util/libs/operator/snap.py
+++ b/test_env_setup_util/libs/operator/snap.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import time
 
 from test_env_setup_util.libs.exceptions import SnapCommandError
 
@@ -13,8 +14,14 @@ def install_snap(session, snap_data):
     risk = snap_data.get("risk")
     branch = snap_data.get("branch")
 
+    retry_on_failure = snap_data.get("retry_on_failure", False)
+    retry_count = snap_data.get("retry_count", 3) if retry_on_failure else None
+    retry_delay = snap_data.get("retry_delay", 5) if retry_on_failure else None
+
     ret = 0
-    installed_rev, installed_tracks = get_snap_info(session, name)
+    installed_rev, installed_tracks = get_snap_info(
+        session, name, retry_on_failure, retry_count, retry_delay
+    )
     if revision == installed_rev.strip("()"):
         logging.info("%s snap has been installed with the same revision", name)
     elif f"{track}/{risk}" in installed_tracks:
@@ -37,7 +44,21 @@ def install_snap(session, snap_data):
         if snap_data.get("mode"):
             _cmd += f" --{snap_data['mode']}"
 
-        ret, _, _ = session.launch_ssh_command(_cmd)
+        if retry_on_failure:
+            for attempt in range(retry_count):
+                ret, _, _ = session.launch_ssh_command(
+                    _cmd, continue_on_error=True
+                )
+                if ret == 0:
+                    break
+                if attempt < retry_count - 1:
+                    time.sleep(retry_delay)
+                else:
+                    raise SnapCommandError(
+                        f"Failed to install snap {name} after {retry_count} retries"
+                    )
+        else:
+            ret, _, _ = session.launch_ssh_command(_cmd)
 
     if snap_data.get("post_commands") and ret == 0:
         command = snap_data["post_commands"]
@@ -46,10 +67,26 @@ def install_snap(session, snap_data):
             raise SnapCommandError(command)
 
 
-def get_snap_info(session, name):
+def get_snap_info(
+    session, name, retry_on_failure=False, retry_count=3, retry_delay=5
+):
 
     command = f"snap info {name}"
-    ret, stdout, _ = session.launch_ssh_command(command)
+    if retry_on_failure:
+        for attempt in range(retry_count):
+            ret, stdout, _ = session.launch_ssh_command(
+                command, continue_on_error=True
+            )
+            if ret == 0:
+                break
+            if attempt < retry_count - 1:
+                time.sleep(retry_delay)
+            else:
+                raise SnapCommandError(
+                    f"Failed to get snap info for {name} after {retry_count} retries"
+                )
+    else:
+        ret, stdout, _ = session.launch_ssh_command(command)
     if ret != 0:
         raise SnapCommandError(command)
 


### PR DESCRIPTION
In CI, we (PE-carmel) are facing many failures due to intermittent network issues in the lab while installing the deb/snap packages.
This adds a configurable retry mechanism, so that we can tune as per our requirements.

retry is optional and current users are not affected by this change!

```
retry_on_failure: set true to retry if the install fails
retry_count: no of retries, by default set to 3
retry_delay: delay between retries, by default 5 seconds
```

https://warthogs.atlassian.net/browse/PECA-1376